### PR TITLE
Fix ModuleNotFoundError in notebook by adding module path

### DIFF
--- a/123_bis.ipynb
+++ b/123_bis.ipynb
@@ -264,6 +264,9 @@
     "outputId": "5ddbd3e2-3687-44bf-b38a-9017d4b33d17"
    },
    "source": [
+    "import os\n",
+    "import sys\n",
+    "sys.path.append(os.path.abspath(os.path.dirname('constants.py')))\n",
     "from constants import PS_RATE_BEFORE_2018, PS_RATE_AFTER_2018\n",
     "from ir_physique_formulas import IR_PHYSIQUE_CALCULATED_COLUMNS, get_ir_physique_formula\n",
     "\n",
@@ -287,7 +290,7 @@
     "# sh.share('your.email@example.com', perm_type='user', role='writer')  # Replace with your email\n",
     "\n",
     "print(f\"Google Sheet created and ready: https://docs.google.com/spreadsheets/d/{sh.id}\")\n",
-    "print(\"Open the link to edit online. Fill in variables in 'Variables_a_renseigner'.\")"
+    "print(\"Open the link to edit online. Fill in variables in 'Variables_a_renseigner'.\")\n"
    ],
    "execution_count": 11,
    "outputs": [


### PR DESCRIPTION
## Summary
- Add current directory to `sys.path` in the notebook before importing project modules.

## Testing
- `python - <<'PY'\nimport sys, os\nsys.path.append(os.path.abspath(os.path.dirname('constants.py')))\nfrom constants import PS_RATE_BEFORE_2018, PS_RATE_AFTER_2018\nprint(PS_RATE_BEFORE_2018, PS_RATE_AFTER_2018)\nPY`


------
https://chatgpt.com/codex/tasks/task_e_68a5ecdc19b8832d94efd2d42b58f2a5