### PR TITLE
Fix module imports in notebook

### DIFF
--- a/123_bis.ipynb
+++ b/123_bis.ipynb
@@ -264,6 +264,13 @@
     "outputId": "5ddbd3e2-3687-44bf-b38a-9017d4b33d17"
    },
    "source": [
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# Ensure repository root is on sys.path\n",
+    "repo_dir = Path().resolve()\n",
+    "sys.path.insert(0, str(repo_dir))\n",
+    "\n",
     "from constants import PS_RATE_BEFORE_2018, PS_RATE_AFTER_2018\n",
     "from ir_physique_formulas import IR_PHYSIQUE_CALCULATED_COLUMNS, get_ir_physique_formula\n",
     "\n",
@@ -287,43 +294,10 @@
     "# sh.share('your.email@example.com', perm_type='user', role='writer')  # Replace with your email\n",
     "\n",
     "print(f\"Google Sheet created and ready: https://docs.google.com/spreadsheets/d/{sh.id}\")\n",
-    "print(\"Open the link to edit online. Fill in variables in 'Variables_a_renseigner'.\")"
+    "print(\"Open the link to edit online. Fill in variables in 'Variables_a_renseigner'.\")\n"
    ],
-   "execution_count": 11,
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "/tmp/ipython-input-378843862.py:67: DeprecationWarning: The order of arguments in worksheet.update() has changed. Please pass values first and range_name secondor used named arguments (range_name=, values=)\n",
-      "  worksheet.update(range_to_update, formula_data, value_input_option='USER_ENTERED')\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Updated formulas in sheet 'Calcul IS' for range 'E2:U11'.\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "/tmp/ipython-input-378843862.py:67: DeprecationWarning: The order of arguments in worksheet.update() has changed. Please pass values first and range_name secondor used named arguments (range_name=, values=)\n",
-      "  worksheet.update(range_to_update, formula_data, value_input_option='USER_ENTERED')\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Updated formulas in sheet 'IR_PersonnePhysique' for range 'P2:BT11'.\n",
-      "Google Sheet created and ready: https://docs.google.com/spreadsheets/d/1pNAj3BffV_0sTnNLhy7clVZIQLSqNw94vfeG8WU2xEQ\n",
-      "Open the link to edit online. Fill in variables in 'Variables_a_renseigner'.\n"
-     ]
-    }
-   ]
+   "execution_count": null,
+   "outputs": []
   }
  ]
 }

--- a/123_bis.ipynb
+++ b/123_bis.ipynb
@@ -264,12 +264,9 @@
     "outputId": "5ddbd3e2-3687-44bf-b38a-9017d4b33d17"
    },
    "source": [
+    "import os\n",
     "import sys\n",
-    "from pathlib import Path\n",
-    "\n",
-    "# Ensure repository root is on sys.path\n",
-    "repo_dir = Path().resolve()\n",
-    "sys.path.insert(0, str(repo_dir))\n",
+    "sys.path.append(os.path.abspath(os.path.dirname('constants.py')))\n",
     "\n",
     "from constants import PS_RATE_BEFORE_2018, PS_RATE_AFTER_2018\n",
     "from ir_physique_formulas import IR_PHYSIQUE_CALCULATED_COLUMNS, get_ir_physique_formula\n",


### PR DESCRIPTION
## Summary
- Ensure `constants` and other local modules are importable by inserting repository root into `sys.path`
- Clean notebook outputs for a lighter commit

## Testing
- `python -m py_compile constants.py create_google_sheet.py ir_physique_formulas.py`
- `python - <<'PY'
import sys
from pathlib import Path
repo_dir = Path().resolve()
sys.path.insert(0, str(repo_dir))
from constants import PS_RATE_BEFORE_2018, PS_RATE_AFTER_2018
print(PS_RATE_BEFORE_2018, PS_RATE_AFTER_2018)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a5ecdc19b8832d94efd2d42b58f2a5